### PR TITLE
#17 Update poms to be compliant to Nexus requirements

### DIFF
--- a/aljebra/pom.xml
+++ b/aljebra/pom.xml
@@ -27,9 +27,9 @@
     http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.jeometry</groupId>
+        <groupId>com.github.hdouss</groupId>
         <artifactId>jeometry</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>aljebra</artifactId>
     <description>Java simple Algebra library abstract API</description>

--- a/aljebra/src/main/java/com/aljebra/field/AbstractField.java
+++ b/aljebra/src/main/java/com/aljebra/field/AbstractField.java
@@ -26,7 +26,7 @@ package com.aljebra.field;
 import com.aljebra.scalar.Scalar;
 
 /**
- * Abstract Field implementation based on {@link Default} implementation
+ * Abstract Field implementation based on {@link Scalar.Default} implementation
  * for returning actual scalar objects.
  * @author Hamdi Douss (douss.hamdi@gmail.com)
  * @version $Id$

--- a/jeometry-api/pom.xml
+++ b/jeometry-api/pom.xml
@@ -27,9 +27,9 @@
     http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.jeometry</groupId>
+        <groupId>com.github.hdouss</groupId>
         <artifactId>jeometry</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>jeometry-api</artifactId>
     <description>Java Geometry library abstract API</description>

--- a/jeometry-api/pom.xml
+++ b/jeometry-api/pom.xml
@@ -35,9 +35,9 @@
     <description>Java Geometry library abstract API</description>
     <dependencies>
         <dependency>
-            <groupId>com.jeometry</groupId>
+            <groupId>com.github.hdouss</groupId>
             <artifactId>aljebra</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
+            <version>1.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/jeometry-double/pom.xml
+++ b/jeometry-double/pom.xml
@@ -27,9 +27,9 @@
     http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.jeometry</groupId>
+        <groupId>com.github.hdouss</groupId>
         <artifactId>jeometry</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>jeometry-double</artifactId>
     <description>Java Geometry library abstract API</description>

--- a/jeometry-double/pom.xml
+++ b/jeometry-double/pom.xml
@@ -35,14 +35,14 @@
     <description>Java Geometry library abstract API</description>
     <dependencies>
         <dependency>
-            <groupId>com.jeometry</groupId>
+            <groupId>com.github.hdouss</groupId>
             <artifactId>aljebra</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
+            <version>1.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.jeometry</groupId>
+            <groupId>com.github.hdouss</groupId>
             <artifactId>jeometry-api</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
+            <version>1.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,10 +26,41 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
     http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.jeometry</groupId>
+    <groupId>com.github.hdouss</groupId>
     <artifactId>jeometry</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
+    <name>${project.groupId}:${project.artifactId}</name>
     <description>Simple 2D Java Geometry library</description>
+    <url>https://github.com/HDouss/jeometry</url>
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>http://www.opensource.org/licenses/mit-license.php</url>
+        </license>
+    </licenses>
+    <developers>
+        <developer>
+            <name>Hamdi Douss</name>
+            <email>douss.hamdi@gmail.com</email>
+            <organization>HDouss</organization>
+            <organizationUrl>https://github.com/HDouss</organizationUrl>
+        </developer>
+    </developers>
+    <scm>
+        <connection>scm:git:git://github.com/hdouss/jeometry.git</connection>
+        <developerConnection>scm:git:ssh://github.com:hdouss/jeometry.git</developerConnection>
+        <url>http://github.com/hdouss/jeometry/tree/master</url>
+    </scm>
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
     <packaging>pom</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -97,7 +128,7 @@
                     <version>1.9</version>
                     <configuration>
                         <forceAjcCompile>true</forceAjcCompile>
-                        <sources/>
+                        <sources />
                         <weaveDirectories>
                             <weaveDirectory>${project.build.directory}/classes</weaveDirectory>
                         </weaveDirectories>
@@ -168,6 +199,85 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.7</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>ossrh</serverId>
+                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.2.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.9.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>2.1</version>
+                <configuration>
+                    <generateBackupPoms>false</generateBackupPoms>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>jeometry-gpg</id>
+            <activation>
+                <property>
+                    <name>gpg.passphrase</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.6</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <configuration>
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
* Adding javadoc generation to the build makes the build fail -> resolved by fixing a javadoc link
* Artifacts signing is only part of `jeometry-gpg` maven profile. This profile is activated when the property `gpg.passphrase` is defined