### PR TITLE
#113 MkAddition and MkMultiplication

### DIFF
--- a/aljebra/src/test/java/com/aljebra/field/MkAddition.java
+++ b/aljebra/src/test/java/com/aljebra/field/MkAddition.java
@@ -1,0 +1,107 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2020, Hamdi Douss
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom
+ * the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ * OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.aljebra.field;
+
+/**
+ * Mock FieldAddition. Gives the ability to see:
+ * - whether neutral or inverse methods are called;
+ * - the number of times the add method was called.
+ * @param <T> scalar types
+ * @since 0.1
+ */
+public final class MkAddition<T> implements FieldAddition<T> {
+
+    /**
+     * Boolean indicating if inverse method was called.
+     */
+    private Boolean inver;
+
+    /**
+     * Integer indicating the number of times the add method was called.
+     */
+    private Integer addd;
+
+    /**
+     * Boolean indicating if neutral method was called.
+     */
+    private Boolean neutrld;
+
+    /**
+     * Neutral element of the addition.
+     */
+    private final T element;
+
+    /**
+     * Ctor.
+     * @param elt Neutral element of the addition.
+     */
+    public MkAddition(final T elt) {
+        this.element = elt;
+        this.neutrld = Boolean.FALSE;
+        this.addd = 0;
+        this.inver = Boolean.FALSE;
+    }
+
+    @Override
+    public T add(final T operand, final T second) {
+        this.addd = this.addd + 1;
+        return operand;
+    }
+
+    @Override
+    public T neutral() {
+        this.neutrld = Boolean.TRUE;
+        return this.element;
+    }
+
+    @Override
+    public T inverse(final T elt) {
+        this.inver = Boolean.TRUE;
+        return elt;
+    }
+
+    /**
+     * Accessor for a boolean indicating if inverse method was called.
+     * @return True if inverse method was called, false otherwise
+     */
+    public Boolean inverted() {
+        return this.inver;
+    }
+
+    /**
+     * Accessor for a number indicating the times the add method was called.
+     * @return Times the add method was called
+     */
+    public Integer added() {
+        return this.addd;
+    }
+
+    /**
+     * Accessor for a boolean indicating if neutral method was called.
+     * @return True if neutral method was called, false otherwise
+     */
+    public Boolean neutraled() {
+        return this.neutrld;
+    }
+}

--- a/aljebra/src/test/java/com/aljebra/field/MkField.java
+++ b/aljebra/src/test/java/com/aljebra/field/MkField.java
@@ -40,6 +40,16 @@ public final class MkField<T> extends AbstractOrderedField<T> implements MetricS
     private final InnerProduct<T> pdt;
 
     /**
+     * Ctor. MkAddition and MkMultiplication are used as implementations.
+     * @param addelt Addition neutral element
+     * @param mulelt Multiplication neutral element
+     * @param pdt Inner product
+     */
+    public MkField(final T addelt, final T mulelt, final InnerProduct<T> pdt) {
+        this(new MkAddition<>(addelt), new MkMultiplication<>(mulelt), pdt);
+    }
+
+    /**
      * Ctor.
      * @param add Addition operation
      * @param mul Multiplication operation

--- a/aljebra/src/test/java/com/aljebra/field/MkMultiplication.java
+++ b/aljebra/src/test/java/com/aljebra/field/MkMultiplication.java
@@ -1,0 +1,107 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2020, Hamdi Douss
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom
+ * the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ * OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.aljebra.field;
+
+/**
+ * Mock FieldMultiplication. Gives the ability to see:
+ * - whether neutral or inverse methods are called;
+ * - the number of times the multiply method was called.
+ * @param <T> scalar types
+ * @since 0.1
+ */
+public final class MkMultiplication<T> implements FieldMultiplication<T> {
+
+    /**
+     * Boolean indicating if inverse method was called.
+     */
+    private Boolean inver;
+
+    /**
+     * Integer indicating the number of times the multiply method was called.
+     */
+    private Integer mult;
+
+    /**
+     * Boolean indicating if neutral method was called.
+     */
+    private Boolean neutrld;
+
+    /**
+     * Neutral element of the multiplication.
+     */
+    private final T element;
+
+    /**
+     * Ctor.
+     * @param elt Neutral element of the multiplication.
+     */
+    public MkMultiplication(final T elt) {
+        this.element = elt;
+        this.neutrld = Boolean.FALSE;
+        this.mult = 0;
+        this.inver = Boolean.FALSE;
+    }
+
+    @Override
+    public T neutral() {
+        this.neutrld = Boolean.TRUE;
+        return this.element;
+    }
+
+    @Override
+    public T inverse(final T elt) {
+        this.inver = Boolean.TRUE;
+        return elt;
+    }
+
+    @Override
+    public T multiply(final T operand, final T second) {
+        this.mult = this.mult + 1;
+        return operand;
+    }
+
+    /**
+     * Accessor for a boolean indicating if inverse method was called.
+     * @return True if inverse method was called, false otherwise
+     */
+    public Boolean inverted() {
+        return this.inver;
+    }
+
+    /**
+     * Accessor for a number indicating the times the multiply method was called.
+     * @return Times the multiply method was called
+     */
+    public Integer multiplied() {
+        return this.mult;
+    }
+
+    /**
+     * Accessor for a boolean indicating if neutral method was called.
+     * @return True if neutral method was called, false otherwise
+     */
+    public Boolean neutraled() {
+        return this.neutrld;
+    }
+}

--- a/aljebra/src/test/java/com/aljebra/metric/scalar/NormTest.java
+++ b/aljebra/src/test/java/com/aljebra/metric/scalar/NormTest.java
@@ -24,8 +24,6 @@
 package com.aljebra.metric.scalar;
 
 import com.aljebra.field.Field;
-import com.aljebra.field.FieldAddition;
-import com.aljebra.field.FieldMultiplication;
 import com.aljebra.field.MetricSpaceField;
 import com.aljebra.field.MkField;
 import com.aljebra.metric.MockProduct;
@@ -56,16 +54,13 @@ public final class NormTest {
     /**
      * {@link Norm} rely on InnerProduct for resolution of actual value.
      */
-    @SuppressWarnings("unchecked")
     @Test
     public void delegatesToInnerProduct() {
         final Vect<Object> first = new FixedVector<>(
             Arrays.asList(new Scalar.Default<>(new Object()))
         );
         final MockProduct<Object> pdt = new MockProduct<>();
-        final MetricSpaceField<Object> field = new MkField<>(
-            Mockito.mock(FieldAddition.class), Mockito.mock(FieldMultiplication.class), pdt
-        );
+        final MetricSpaceField<Object> field = new MkField<>(new Object(), new Object(), pdt);
         new Norm<>(first).value(field);
         final Optional<Vect<Object>> params = pdt.norm();
         MatcherAssert.assertThat(

--- a/aljebra/src/test/java/com/aljebra/metric/scalar/ProductTest.java
+++ b/aljebra/src/test/java/com/aljebra/metric/scalar/ProductTest.java
@@ -24,8 +24,6 @@
 package com.aljebra.metric.scalar;
 
 import com.aljebra.field.Field;
-import com.aljebra.field.FieldAddition;
-import com.aljebra.field.FieldMultiplication;
 import com.aljebra.field.MetricSpaceField;
 import com.aljebra.field.MkField;
 import com.aljebra.metric.MockProduct;
@@ -56,16 +54,13 @@ public final class ProductTest {
     /**
      * {@link Product} rely on InnerProduct for resolution of actual value.
      */
-    @SuppressWarnings("unchecked")
     @Test
     public void delegatesToInnerProduct() {
         final int dim = 6;
         final Vect<Object> first = new FixedVector<>(Arrays.asList(ProductTest.scalars(dim)));
         final Vect<Object> second = new FixedVector<>(Arrays.asList(ProductTest.scalars(dim)));
         final MockProduct<Object> pdt = new MockProduct<>();
-        final MetricSpaceField<Object> field = new MkField<>(
-            Mockito.mock(FieldAddition.class), Mockito.mock(FieldMultiplication.class), pdt
-        );
+        final MetricSpaceField<Object> field = new MkField<>(new Object(), new Object(), pdt);
         new Product<>(first, second).value(field);
         final Optional<List<Vect<Object>>> params = pdt.product();
         MatcherAssert.assertThat(

--- a/aljebra/src/test/java/com/aljebra/scalar/AddIdentityTest.java
+++ b/aljebra/src/test/java/com/aljebra/scalar/AddIdentityTest.java
@@ -24,7 +24,7 @@
 package com.aljebra.scalar;
 
 import com.aljebra.field.Field;
-import com.aljebra.field.FieldAddition;
+import com.aljebra.field.MkAddition;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -43,11 +43,13 @@ public final class AddIdentityTest {
     @Test
     public void addIdentityDelegatesToFieldAddition() {
         final Field<Object> field = Mockito.mock(Field.class);
-        final FieldAddition<Object> add = Mockito.mock(FieldAddition.class);
+        final MkAddition<Object> add = new MkAddition<>(new Object());
         Mockito.when(field.addition()).thenReturn(add);
         new AddIdentity<>().value(field);
         Mockito.verify(field).addition();
-        Mockito.verify(add).neutral();
+        MatcherAssert.assertThat(
+            add.neutraled(), Matchers.is(true)
+        );
     }
 
     /**

--- a/aljebra/src/test/java/com/aljebra/scalar/AddInverseTest.java
+++ b/aljebra/src/test/java/com/aljebra/scalar/AddInverseTest.java
@@ -24,7 +24,7 @@
 package com.aljebra.scalar;
 
 import com.aljebra.field.Field;
-import com.aljebra.field.FieldAddition;
+import com.aljebra.field.MkAddition;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -44,12 +44,14 @@ public final class AddInverseTest {
     @Test
     public void addInverseDelegatesToFieldAddition() {
         final Field<Object> field = Mockito.mock(Field.class);
-        final FieldAddition<Object> add = Mockito.mock(FieldAddition.class);
+        final MkAddition<Object> add = new MkAddition<>(new Object());
         Mockito.when(field.addition()).thenReturn(add);
         final Scalar<Object> scalar = new Scalar.Default<>(new Object());
         new AddInverse<>(scalar).value(field);
         Mockito.verify(field).addition();
-        Mockito.verify(add).inverse(Mockito.any());
+        MatcherAssert.assertThat(
+            add.inverted(), Matchers.is(true)
+        );
     }
 
     /**

--- a/aljebra/src/test/java/com/aljebra/scalar/AddTest.java
+++ b/aljebra/src/test/java/com/aljebra/scalar/AddTest.java
@@ -24,8 +24,9 @@
 package com.aljebra.scalar;
 
 import com.aljebra.field.Field;
-import com.aljebra.field.FieldAddition;
+import com.aljebra.field.MkAddition;
 import java.util.Arrays;
+import java.util.List;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -96,14 +97,16 @@ public final class AddTest {
         final Scalar<Object> first = new Scalar.Default<>(new Object());
         final Scalar<Object> second = new Scalar.Default<>(new Object());
         final Field<Object> field = Mockito.mock(Field.class);
-        final FieldAddition<Object> add = Mockito.mock(FieldAddition.class);
+        final MkAddition<Object> add = new MkAddition<>(new Object());
         Mockito.when(field.addition()).thenReturn(add);
-        new Add<>(Arrays.asList(first, second, first)).value(field);
+        final List<Scalar<Object>> operands = Arrays.asList(first, second, first);
+        new Add<>(operands).value(field);
         Mockito.verify(field).addition();
-        Mockito.verify(add).neutral();
-        final int invocations = 3;
-        Mockito.verify(add, Mockito.times(invocations)).add(
-            Mockito.any(), Mockito.any()
+        MatcherAssert.assertThat(
+            add.neutraled(), Matchers.is(true)
+        );
+        MatcherAssert.assertThat(
+            add.added(), Matchers.is(operands.size())
         );
     }
 }

--- a/aljebra/src/test/java/com/aljebra/scalar/DiffTest.java
+++ b/aljebra/src/test/java/com/aljebra/scalar/DiffTest.java
@@ -24,7 +24,7 @@
 package com.aljebra.scalar;
 
 import com.aljebra.field.Field;
-import com.aljebra.field.FieldAddition;
+import com.aljebra.field.MkAddition;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -102,12 +102,16 @@ public final class DiffTest {
         final Scalar<Object> first = new Scalar.Default<>(new Object());
         final Scalar<Object> second = new Scalar.Default<>(new Object());
         final Field<Object> field = Mockito.mock(Field.class);
-        final FieldAddition<Object> add = Mockito.mock(FieldAddition.class);
+        final MkAddition<Object> add = new MkAddition<>(new Object());
         Mockito.when(field.addition()).thenReturn(add);
         new Diff<>(first, second).value(field);
         Mockito.verify(field).addition();
-        Mockito.verify(add).inverse(Mockito.any());
-        Mockito.verify(add).add(Mockito.any(), Mockito.any());
+        MatcherAssert.assertThat(
+            add.inverted(), Matchers.is(true)
+        );
+        MatcherAssert.assertThat(
+            add.added(), Matchers.greaterThan(0)
+        );
     }
 
     /**

--- a/aljebra/src/test/java/com/aljebra/scalar/DivisionTest.java
+++ b/aljebra/src/test/java/com/aljebra/scalar/DivisionTest.java
@@ -24,7 +24,7 @@
 package com.aljebra.scalar;
 
 import com.aljebra.field.Field;
-import com.aljebra.field.FieldMultiplication;
+import com.aljebra.field.MkMultiplication;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -89,16 +89,18 @@ public final class DivisionTest {
     @Test
     public void divisionDelegatesToFieldMultiplication() {
         final Field<Object> field = Mockito.mock(Field.class);
-        final FieldMultiplication<Object> mult = Mockito.mock(
-            FieldMultiplication.class
-        );
+        final MkMultiplication<Object> mult = new MkMultiplication<>(new Object());
         Mockito.when(field.multiplication()).thenReturn(mult);
         new Division<>(
             new Scalar.Default<>(new Object()), new Scalar.Default<>(new Object())
         ).value(field);
         Mockito.verify(field).multiplication();
-        Mockito.verify(mult).inverse(Mockito.any());
-        Mockito.verify(mult).multiply(Mockito.any(), Mockito.any());
+        MatcherAssert.assertThat(
+            mult.inverted(), Matchers.is(true)
+        );
+        MatcherAssert.assertThat(
+            mult.multiplied(), Matchers.greaterThan(0)
+        );
     }
 
     /**

--- a/aljebra/src/test/java/com/aljebra/scalar/MultIdentityTest.java
+++ b/aljebra/src/test/java/com/aljebra/scalar/MultIdentityTest.java
@@ -24,7 +24,7 @@
 package com.aljebra.scalar;
 
 import com.aljebra.field.Field;
-import com.aljebra.field.FieldMultiplication;
+import com.aljebra.field.MkMultiplication;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -44,13 +44,13 @@ public final class MultIdentityTest {
     @Test
     public void multIdentityDelegatesToFieldMultiplication() {
         final Field<Object> field = Mockito.mock(Field.class);
-        final FieldMultiplication<Object> mult = Mockito.mock(
-            FieldMultiplication.class
-        );
+        final MkMultiplication<Object> mult = new MkMultiplication<>(new Object());
         Mockito.when(field.multiplication()).thenReturn(mult);
         new MultIdentity<>().value(field);
         Mockito.verify(field).multiplication();
-        Mockito.verify(mult).neutral();
+        MatcherAssert.assertThat(
+            mult.neutraled(), Matchers.is(true)
+        );
     }
 
     /**

--- a/aljebra/src/test/java/com/aljebra/scalar/MultInverseTest.java
+++ b/aljebra/src/test/java/com/aljebra/scalar/MultInverseTest.java
@@ -24,7 +24,7 @@
 package com.aljebra.scalar;
 
 import com.aljebra.field.Field;
-import com.aljebra.field.FieldMultiplication;
+import com.aljebra.field.MkMultiplication;
 import com.aljebra.field.impl.doubles.Decimal;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -53,14 +53,14 @@ public final class MultInverseTest {
     @Test
     public void multInverseDelegatesToFieldMultiplication() {
         final Field<Object> field = Mockito.mock(Field.class);
-        final FieldMultiplication<Object> mult = Mockito.mock(
-            FieldMultiplication.class
-        );
+        final MkMultiplication<Object> mult = new MkMultiplication<>(new Object());
         Mockito.when(field.multiplication()).thenReturn(mult);
         final Scalar<Object> scalar = new Scalar.Default<>(new Object());
         new MultInverse<>(scalar).value(field);
         Mockito.verify(field).multiplication();
-        Mockito.verify(mult).inverse(Mockito.any());
+        MatcherAssert.assertThat(
+            mult.inverted(), Matchers.is(true)
+        );
     }
 
     /**

--- a/aljebra/src/test/java/com/aljebra/scalar/MultiplicationTest.java
+++ b/aljebra/src/test/java/com/aljebra/scalar/MultiplicationTest.java
@@ -24,8 +24,9 @@
 package com.aljebra.scalar;
 
 import com.aljebra.field.Field;
-import com.aljebra.field.FieldMultiplication;
+import com.aljebra.field.MkMultiplication;
 import java.util.Arrays;
+import java.util.List;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -60,15 +61,16 @@ public final class MultiplicationTest {
         final Scalar<Object> first = new Scalar.Default<>(new Object());
         final Scalar<Object> second = new Scalar.Default<>(new Object());
         final Field<Object> field = Mockito.mock(Field.class);
-        final FieldMultiplication<Object> mult = Mockito.mock(
-            FieldMultiplication.class
-        );
+        final MkMultiplication<Object> mult = new MkMultiplication<>(new Object());
         Mockito.when(field.multiplication()).thenReturn(mult);
-        new Multiplication<>(Arrays.asList(first, second)).value(field);
+        final List<Scalar<Object>> operands = Arrays.asList(first, second);
+        new Multiplication<>(operands).value(field);
         Mockito.verify(field).multiplication();
-        Mockito.verify(mult).neutral();
-        Mockito.verify(mult, Mockito.times(2)).multiply(
-            Mockito.any(), Mockito.any()
+        MatcherAssert.assertThat(
+            mult.neutraled(), Matchers.is(true)
+        );
+        MatcherAssert.assertThat(
+            mult.multiplied(), Matchers.is(operands.size())
         );
     }
 }


### PR DESCRIPTION
Resolving issue #113 
Implement mocking for FieldAddition and FieldMultiplication.
Mock objects can report whether methods were called or for some the number of times they were called.
Add a constructor for MkField that builds mock addition and mock multiplication.