### PR TITLE
#149 package aljebra test classes

### DIFF
--- a/aljebra/pom.xml
+++ b/aljebra/pom.xml
@@ -33,6 +33,21 @@
     </parent>
     <artifactId>aljebra</artifactId>
     <description>Java simple Algebra library abstract API</description>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -59,4 +74,5 @@
             <artifactId>lombok</artifactId>
         </dependency>
     </dependencies>
+    
 </project>

--- a/jeometry-api/pom.xml
+++ b/jeometry-api/pom.xml
@@ -63,5 +63,12 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.github.hdouss</groupId>
+            <artifactId>aljebra</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/jeometry-api/src/test/java/com/jeometry/twod/point/RandomPointTest.java
+++ b/jeometry-api/src/test/java/com/jeometry/twod/point/RandomPointTest.java
@@ -24,6 +24,7 @@
 package com.jeometry.twod.point;
 
 import com.aljebra.field.impl.doubles.Decimal;
+import com.aljebra.field.mock.SpyField;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -39,9 +40,20 @@ public final class RandomPointTest {
      */
     @Test
     public void buildsANonVerticalPoint() {
-        final XyPoint<Double> vector = new RandomPoint<>();
         MatcherAssert.assertThat(
-            vector.xcoor().value(new Decimal()), Matchers.not(0.)
+            new RandomPoint<Double>().xcoor().value(new Decimal()), Matchers.not(0.)
+        );
+    }
+
+    /**
+     * {@link RandomPoint} coordinate evaluations delegates to field randomization.
+     */
+    @Test
+    public void buildsRandomCoordinates() {
+        final SpyField<Double> field = new SpyField<>(new Decimal());
+        new RandomPoint<Double>().ycoor().value(field);
+        MatcherAssert.assertThat(
+            field.calls().randomed(), Matchers.equalTo(true)
         );
     }
 }


### PR DESCRIPTION
Resolving issue #149 
`aljebra` module test classes are packaged.
add a dependency for `jeometry-api` on `aljebra` test classes with `test` scope.
Modify RandomPointTest as a showcase.
