### PR TITLE
#163 remove predicate default methods

### DIFF
--- a/aljebra/src/main/java/com/aljebra/scalar/condition/Predicate.java
+++ b/aljebra/src/main/java/com/aljebra/scalar/condition/Predicate.java
@@ -24,8 +24,6 @@
 package com.aljebra.scalar.condition;
 
 import com.aljebra.field.Field;
-import com.aljebra.scalar.Scalar;
-import com.aljebra.scalar.Throwing;
 
 /**
  * Predicate interface. A predicate could be resolved to true or false given
@@ -42,27 +40,4 @@ public interface Predicate<T> {
      */
     boolean resolve(Field<T> field);
 
-    /**
-     * Returns a scalar that evaluates to the first passed scalar if this
-     * predicate is true, and evaluates to the second passed scalar if this
-     * predicate is false.
-     * @param truth Scalar if this predicate is true
-     * @param lies Scalar if this predicate is false
-     * @return A scalar whose evaluation depends on this predicate
-     */
-    default Scalar<T> ifElse(Scalar<T> truth, Scalar<T> lies) {
-        return new Ternary<T>(this, truth, lies);
-    }
-
-    /**
-     * Returns a scalar that evaluates to the first passed scalar if this
-     * predicate is true, and throws the passed exception if this
-     * predicate is false.
-     * @param truth Scalar if this predicate is true
-     * @param err Exception to throw if this predicate is false
-     * @return A scalar whose evaluation depends on this predicate
-     */
-    default Scalar<T> ifElse(Scalar<T> truth, RuntimeException err) {
-        return this.ifElse(truth, new Throwing<T>(err));
-    }
 }

--- a/aljebra/src/test/java/com/aljebra/scalar/condition/NotTest.java
+++ b/aljebra/src/test/java/com/aljebra/scalar/condition/NotTest.java
@@ -24,10 +24,6 @@
 package com.aljebra.scalar.condition;
 
 import com.aljebra.field.mock.MkField;
-import com.aljebra.field.mock.SpyField;
-import com.aljebra.scalar.Scalar;
-import java.util.List;
-import java.util.Optional;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Rule;
@@ -68,30 +64,4 @@ public final class NotTest {
         );
     }
 
-    /**
-     * {@link Not} can build a ternary.
-     */
-    @Test
-    public void buildsTernary() {
-        final Scalar<Object> first = new Scalar.Default<>(new Object());
-        final Scalar<Object> second = new Scalar.Default<>(new Object());
-        final SpyField<Object> field = new SpyField<>(new Object(), new Object());
-        new Not<>(new False<>()).ifElse(first, second).value(field);
-        final Optional<List<Scalar<Object>>> params = field.calls().actuals();
-        MatcherAssert.assertThat(params.isPresent(), Matchers.equalTo(true));
-        MatcherAssert.assertThat(params.get().contains(first), Matchers.equalTo(true));
-        MatcherAssert.assertThat(params.get().contains(second), Matchers.equalTo(false));
-    }
-
-    /**
-     * {@link Not} can build a throwing ternary.
-     */
-    @Test
-    public void buildsThrowing() {
-        final RuntimeException err = new RuntimeException();
-        this.thrown.expect(err.getClass());
-        new Not<>(new True<>()).ifElse(
-            new Scalar.Default<>(new Object()), err
-        ).value(new MkField<>(new Object(), new Object()));
-    }
 }

--- a/jeometry-api/src/main/java/com/jeometry/twod/line/analytics/LineAnalytics.java
+++ b/jeometry-api/src/main/java/com/jeometry/twod/line/analytics/LineAnalytics.java
@@ -74,4 +74,12 @@ public final class LineAnalytics<T> {
         return new Vertical<>(this.line);
     }
 
+    /**
+     * Calculates the ordinate of the line point by its abcissa.
+     * @param abcissa Point abcissa
+     * @return A scalar representing the ordinate
+     */
+    public Scalar<T> ordinate(final Scalar<T> abcissa) {
+        return new LinePointOrdinate<>(this.line, abcissa);
+    }
 }

--- a/jeometry-api/src/main/java/com/jeometry/twod/segment/CircleChord.java
+++ b/jeometry-api/src/main/java/com/jeometry/twod/segment/CircleChord.java
@@ -24,6 +24,7 @@
 package com.jeometry.twod.segment;
 
 import com.aljebra.scalar.Throwing;
+import com.aljebra.scalar.condition.Ternary;
 import com.aljebra.vector.FixedVector;
 import com.aljebra.vector.Vect;
 import com.jeometry.twod.circle.Circle;
@@ -69,16 +70,18 @@ public class CircleChord<T> extends PtsSegment<T> {
      */
     private static <T> Vect<T> extremity(final Vect<T> point, final Circle<T> circle) {
         final PointInCircle<T> predicate = new PointInCircle<>(point, circle);
-        final IllegalArgumentException err = new IllegalArgumentException(
-            String.format(
-                "Unable to build a chord of %s passing by the point %s.",
-                circle, point
+        final Throwing<T> err = new Throwing<>(
+            new IllegalArgumentException(
+                String.format(
+                    "Unable to build a chord of %s passing by the point %s.",
+                    circle, point
+                )
             )
         );
         return new FixedVector<>(
             Arrays.asList(
-                predicate.ifElse(point.coords()[0], err),
-                predicate.ifElse(point.coords()[1], err)
+                new Ternary<>(predicate, point.coords()[0], err),
+                new Ternary<>(predicate, point.coords()[1], err)
             )
         );
     }

--- a/jeometry-api/src/main/java/com/jeometry/twod/segment/CircleDiameter.java
+++ b/jeometry-api/src/main/java/com/jeometry/twod/segment/CircleDiameter.java
@@ -24,6 +24,7 @@
 package com.jeometry.twod.segment;
 
 import com.aljebra.scalar.Throwing;
+import com.aljebra.scalar.condition.Ternary;
 import com.aljebra.vector.FixedVector;
 import com.aljebra.vector.Vect;
 import com.jeometry.twod.circle.Circle;
@@ -73,16 +74,18 @@ public class CircleDiameter<T> extends PtsSegment<T> {
      */
     private static <T> Vect<T> extremity(final Vect<T> point, final Circle<T> circle) {
         final PointInCircle<T> predicate = new PointInCircle<>(point, circle);
-        final IllegalArgumentException err = new IllegalArgumentException(
-            String.format(
-                "Unable to build a chord of %s passing by the point %s.",
-                circle, point
+        final Throwing<T> err = new Throwing<>(
+            new IllegalArgumentException(
+                String.format(
+                    "Unable to build a chord of %s passing by the point %s.",
+                    circle, point
+                )
             )
         );
         return new FixedVector<>(
             Arrays.asList(
-                predicate.ifElse(point.coords()[0], err),
-                predicate.ifElse(point.coords()[1], err)
+                new Ternary<>(predicate, point.coords()[0], err),
+                new Ternary<>(predicate, point.coords()[1], err)
             )
         );
     }


### PR DESCRIPTION
Resolving issue #163 
Remove Predicate interface default methods.
Replace by Ternary usage
Refactor LineIntersectPoint, so its class data abstraction coupling remains under 8.