### PR TITLE
#192 making AbstractAwtPaint immutable

### DIFF
--- a/jeometry-double/src/main/java/com/jeometry/render/RenderSupport.java
+++ b/jeometry-double/src/main/java/com/jeometry/render/RenderSupport.java
@@ -21,8 +21,10 @@
  * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
  * OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.jeometry.twod;
+package com.jeometry.render;
 
+import com.jeometry.twod.Shape;
+import java.awt.Graphics2D;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -56,9 +58,10 @@ public final class RenderSupport implements Renderer {
     }
 
     @Override
-    public void render(final Shape<?> renderable) {
+    public void render(final Shape<?> renderable, final Surface context,
+        final Graphics2D graphics) {
         if (this.supports(renderable)) {
-            this.origin.render(renderable);
+            this.origin.render(renderable, context, graphics);
         }
     }
 

--- a/jeometry-double/src/main/java/com/jeometry/render/Renderer.java
+++ b/jeometry-double/src/main/java/com/jeometry/render/Renderer.java
@@ -21,7 +21,10 @@
  * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
  * OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.jeometry.twod;
+package com.jeometry.render;
+
+import com.jeometry.twod.Shape;
+import java.awt.Graphics2D;
 
 /**
  * Renderer interface capable of rendering a {@link Shape}.
@@ -32,6 +35,8 @@ public interface Renderer {
     /**
      * Renders a {@link Shape}.
      * @param renderable Renderable to render
+     * @param context Surface to draw on
+     * @param graphics Graphics object with which to draw
      */
-    void render(Shape<?> renderable);
+    void render(Shape<?> renderable, Surface context, Graphics2D graphics);
 }

--- a/jeometry-double/src/main/java/com/jeometry/render/Surface.java
+++ b/jeometry-double/src/main/java/com/jeometry/render/Surface.java
@@ -68,6 +68,13 @@ public final class Surface {
     }
 
     /**
+     * Default Ctor especially for testing purposes, with 1-scale, 0 dimesions and 0,0 center.
+     */
+    public Surface() {
+        this(new Dimension(0, 0), 1, new DblPoint(0., 0.));
+    }
+
+    /**
      * Accessor for the height.
      * @return Height of drawable surface
      */

--- a/jeometry-double/src/main/java/com/jeometry/render/awt/AbstractAwtPaint.java
+++ b/jeometry-double/src/main/java/com/jeometry/render/awt/AbstractAwtPaint.java
@@ -24,11 +24,11 @@
 package com.jeometry.render.awt;
 
 import com.aljebra.field.Field;
+import com.jeometry.render.RenderSupport;
+import com.jeometry.render.Renderer;
 import com.jeometry.render.Surface;
 import com.jeometry.render.awt.style.AwtStroke;
-import com.jeometry.twod.RenderSupport;
 import com.jeometry.twod.Renderable;
-import com.jeometry.twod.Renderer;
 import com.jeometry.twod.Shape;
 import com.jeometry.twod.style.Stroke;
 import java.awt.Graphics2D;
@@ -49,16 +49,6 @@ public abstract class AbstractAwtPaint<T extends Renderable> implements Renderer
     private final Field<Double> fld;
 
     /**
-     * {@link Graphics2D} to draw on.
-     */
-    private Graphics2D graphics;
-
-    /**
-     * {@link Surface} describing drawing context.
-     */
-    private Surface context;
-
-    /**
      * Supported class that can be drawn.
      */
     private final Class<?> clazz;
@@ -74,41 +64,26 @@ public abstract class AbstractAwtPaint<T extends Renderable> implements Renderer
         this.clazz = clazz;
     }
 
-    /**
-     * Sets current {@link Graphics2D} to draw on.
-     * @param graphic Graphics to set
-     */
-    public final void setGraphics(final Graphics2D graphic) {
-        this.graphics = graphic;
-    }
-
-    /**
-     * Sets current {@link Surface} for drawing.
-     * @param ctx Passed {@link Surface} to set
-     */
-    public final void setContext(final Surface ctx) {
-        this.context = ctx;
-    }
-
     @Override
-    public final void render(final Shape<?> renderable) {
+    public final void render(final Shape<?> renderable, final Surface context,
+        final Graphics2D graphics) {
         new RenderSupport(
             new Renderer() {
                 @SuppressWarnings("unchecked")
                 @Override
-                public void render(final Shape<?> renderable) {
-                    final Graphics2D graph = AbstractAwtPaint.this.graphics;
+                public void render(final Shape<?> renderable, final Surface context,
+                    final Graphics2D graphics) {
                     final Stroke stroke = renderable.style().stroke();
-                    graph.setStroke(new AwtStroke(stroke));
-                    graph.setColor(stroke.color());
+                    graphics.setStroke(new AwtStroke(stroke));
+                    graphics.setColor(stroke.color());
                     AbstractAwtPaint.this.draw(
-                        ((Class<Shape<T>>) (Class<?>) Shape.class).cast(renderable), graph,
-                        AbstractAwtPaint.this.context
+                        ((Class<Shape<T>>) (Class<?>) Shape.class).cast(renderable), graphics,
+                        context
                     );
                 }
             },
             this.clazz
-        ).render(renderable);
+        ).render(renderable, context, graphics);
     }
 
     /**

--- a/jeometry-double/src/main/java/com/jeometry/render/awt/AwtDrawableSurface.java
+++ b/jeometry-double/src/main/java/com/jeometry/render/awt/AwtDrawableSurface.java
@@ -114,10 +114,8 @@ public final class AwtDrawableSurface extends JPanel {
             final Surface context = this.context();
             surface.setColor(Color.BLACK);
             for (final AbstractAwtPaint<?> painter : this.painters) {
-                painter.setGraphics(surface);
-                painter.setContext(context);
                 for (final Shape<?> shape : this.figure) {
-                    painter.render(shape);
+                    painter.render(shape, context, surface);
                 }
             }
             this.axis(surface);

--- a/jeometry-double/src/test/java/com/jeometry/render/RenderSupportTest.java
+++ b/jeometry-double/src/test/java/com/jeometry/render/RenderSupportTest.java
@@ -21,9 +21,12 @@
  * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
  * OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.jeometry.twod;
+package com.jeometry.render;
 
+import com.jeometry.twod.Renderable;
+import com.jeometry.twod.Shape;
 import com.jeometry.twod.line.Line;
+import java.awt.Graphics2D;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -40,10 +43,12 @@ public final class RenderSupportTest {
     @Test
     public void delegatesToWrappedWhenSupported() {
         final Renderer rend = Mockito.mock(Renderer.class);
+        final Graphics2D graphics = Mockito.mock(Graphics2D.class);
+        final Surface surface = new Surface();
         final Shape<?> shape = new Shape<>(Mockito.mock(Line.class));
         final RenderSupport renderer = new RenderSupport(rend, Line.class);
-        renderer.render(shape);
-        Mockito.verify(rend).render(shape);
+        renderer.render(shape, surface, graphics);
+        Mockito.verify(rend).render(shape, surface, graphics);
     }
 
     /**
@@ -52,10 +57,12 @@ public final class RenderSupportTest {
     @Test
     public void ignoresUnsupportedShape() {
         final Renderer rend = Mockito.mock(Renderer.class);
+        final Graphics2D graphics = Mockito.mock(Graphics2D.class);
+        final Surface surface = new Surface();
         final Shape<?> shape = new Shape<>(Mockito.mock(Renderable.class));
         final RenderSupport renderer = new RenderSupport(rend, Line.class);
-        renderer.render(shape);
-        Mockito.verify(rend, Mockito.never()).render(shape);
+        renderer.render(shape, surface, graphics);
+        Mockito.verify(rend, Mockito.never()).render(shape, surface, graphics);
     }
 
 }

--- a/jeometry-double/src/test/java/com/jeometry/render/SurfaceTest.java
+++ b/jeometry-double/src/test/java/com/jeometry/render/SurfaceTest.java
@@ -63,4 +63,23 @@ public final class SurfaceTest {
         );
     }
 
+    /**
+     * {@link Surface} can build a default surface.
+     */
+    @Test
+    public void buildsDefault() {
+        final Surface ctx = new Surface();
+        MatcherAssert.assertThat(
+            ctx.center(), Matchers.equalTo(new DblPoint(0., 0.))
+        );
+        MatcherAssert.assertThat(
+            ctx.height(), Matchers.equalTo(0)
+        );
+        MatcherAssert.assertThat(
+            ctx.width(), Matchers.equalTo(0)
+        );
+        MatcherAssert.assertThat(
+            ctx.scale(), Matchers.equalTo(1.)
+        );
+    }
 }

--- a/jeometry-double/src/test/java/com/jeometry/render/awt/AwtAngleTest.java
+++ b/jeometry-double/src/test/java/com/jeometry/render/awt/AwtAngleTest.java
@@ -46,9 +46,11 @@ public final class AwtAngleTest {
     public void rendersAngles() {
         final SpyAngle<Double> angle = new SpyAngle<>();
         final AwtAngle painter = new AwtAngle(new Decimal());
-        painter.setContext(new AwtDrawableSurface().context());
-        painter.setGraphics(Mockito.mock(Graphics2D.class));
-        painter.render(new Shape<>(angle));
+        painter.render(
+            new Shape<>(angle),
+            new AwtDrawableSurface().context(),
+            Mockito.mock(Graphics2D.class)
+        );
         MatcherAssert.assertThat(angle.started(), Matchers.equalTo(true));
     }
 
@@ -59,9 +61,11 @@ public final class AwtAngleTest {
     public void doesNotRenderOthers() {
         final SpyLine<Double> render = new SpyLine<>();
         final AwtAngle painter = new AwtAngle(new Decimal());
-        painter.setContext(new AwtDrawableSurface().context());
-        painter.setGraphics(Mockito.mock(Graphics2D.class));
-        painter.render(new Shape<>(render));
+        painter.render(
+            new Shape<>(render),
+            new AwtDrawableSurface().context(),
+            Mockito.mock(Graphics2D.class)
+        );
         MatcherAssert.assertThat(render.pointed(), Matchers.equalTo(false));
         MatcherAssert.assertThat(render.directioned(), Matchers.equalTo(false));
     }

--- a/jeometry-double/src/test/java/com/jeometry/render/awt/AwtArcTest.java
+++ b/jeometry-double/src/test/java/com/jeometry/render/awt/AwtArcTest.java
@@ -46,9 +46,11 @@ public final class AwtArcTest {
     public void rendersArcs() {
         final SpyArc<Double> arc = new SpyArc<>();
         final AwtArc painter = new AwtArc(new Decimal());
-        painter.setContext(new AwtDrawableSurface().context());
-        painter.setGraphics(Mockito.mock(Graphics2D.class));
-        painter.render(new Shape<>(arc));
+        painter.render(
+            new Shape<>(arc),
+            new AwtDrawableSurface().context(),
+            Mockito.mock(Graphics2D.class)
+        );
         MatcherAssert.assertThat(arc.centered(), Matchers.equalTo(true));
     }
 
@@ -59,9 +61,11 @@ public final class AwtArcTest {
     public void doesNotRenderOthers() {
         final SpyLine<Double> render = new SpyLine<>();
         final AwtArc painter = new AwtArc(new Decimal());
-        painter.setContext(new AwtDrawableSurface().context());
-        painter.setGraphics(Mockito.mock(Graphics2D.class));
-        painter.render(new Shape<>(render));
+        painter.render(
+            new Shape<>(render),
+            new AwtDrawableSurface().context(),
+            Mockito.mock(Graphics2D.class)
+        );
         MatcherAssert.assertThat(render.pointed(), Matchers.equalTo(false));
         MatcherAssert.assertThat(render.directioned(), Matchers.equalTo(false));
     }

--- a/jeometry-double/src/test/java/com/jeometry/render/awt/AwtCircleTest.java
+++ b/jeometry-double/src/test/java/com/jeometry/render/awt/AwtCircleTest.java
@@ -49,14 +49,16 @@ public final class AwtCircleTest {
     public void rendersCircles() {
         final SpyCircle<Double> circle = new SpyCircle<>();
         final AwtCircle painter = new AwtCircle(new Decimal());
-        painter.setContext(new AwtDrawableSurface().context());
-        painter.setGraphics(Mockito.mock(Graphics2D.class));
         final Style style = Mockito.mock(Style.class);
         Mockito.when(style.stroke()).thenReturn(
             Mockito.mock(Stroke.class)
         );
         Mockito.when(style.fill()).thenReturn(Mockito.mock(Fill.class));
-        painter.render(new Shape<>(circle, style));
+        painter.render(
+            new Shape<>(circle, style),
+            new AwtDrawableSurface().context(),
+            Mockito.mock(Graphics2D.class)
+        );
         Mockito.verify(style).fill();
         Mockito.verify(style).stroke();
         MatcherAssert.assertThat(circle.centered(), Matchers.equalTo(true));
@@ -69,9 +71,11 @@ public final class AwtCircleTest {
     public void doesNotRenderOthers() {
         final SpyLine<Double> render = new SpyLine<>();
         final AwtCircle painter = new AwtCircle(new Decimal());
-        painter.setContext(new AwtDrawableSurface().context());
-        painter.setGraphics(Mockito.mock(Graphics2D.class));
-        painter.render(new Shape<>(render));
+        painter.render(
+            new Shape<>(render),
+            new AwtDrawableSurface().context(),
+            Mockito.mock(Graphics2D.class)
+        );
         MatcherAssert.assertThat(render.pointed(), Matchers.equalTo(false));
         MatcherAssert.assertThat(render.directioned(), Matchers.equalTo(false));
     }

--- a/jeometry-double/src/test/java/com/jeometry/render/awt/AwtLineTest.java
+++ b/jeometry-double/src/test/java/com/jeometry/render/awt/AwtLineTest.java
@@ -47,9 +47,11 @@ public final class AwtLineTest {
     public void rendersLines() {
         final SpyLine<Double> line = new SpyLine<>();
         final AwtLine painter = new AwtLine(new Decimal());
-        painter.setContext(new AwtDrawableSurface().context());
-        painter.setGraphics(Mockito.mock(Graphics2D.class));
-        painter.render(new Shape<>(line));
+        painter.render(
+            new Shape<>(line),
+            new AwtDrawableSurface().context(),
+            Mockito.mock(Graphics2D.class)
+        );
         MatcherAssert.assertThat(line.directioned(), Matchers.equalTo(true));
         MatcherAssert.assertThat(line.pointed(), Matchers.equalTo(true));
     }
@@ -61,9 +63,11 @@ public final class AwtLineTest {
     public void rendersVertical() {
         final SpyLine<Double> line = new SpyLine<>(new VerticalLine<>());
         final AwtLine painter = new AwtLine(new Decimal());
-        painter.setContext(new AwtDrawableSurface().context());
-        painter.setGraphics(Mockito.mock(Graphics2D.class));
-        painter.render(new Shape<>(line));
+        painter.render(
+            new Shape<>(line),
+            new AwtDrawableSurface().context(),
+            Mockito.mock(Graphics2D.class)
+        );
         MatcherAssert.assertThat(line.directioned(), Matchers.equalTo(true));
         MatcherAssert.assertThat(line.pointed(), Matchers.equalTo(true));
     }
@@ -75,9 +79,11 @@ public final class AwtLineTest {
     public void doesNotRenderOthers() {
         final SpyAngle<Double> render = new SpyAngle<>();
         final AwtLine painter = new AwtLine(new Decimal());
-        painter.setContext(new AwtDrawableSurface().context());
-        painter.setGraphics(Mockito.mock(Graphics2D.class));
-        painter.render(new Shape<>(render));
+        painter.render(
+            new Shape<>(render),
+            new AwtDrawableSurface().context(),
+            Mockito.mock(Graphics2D.class)
+        );
         MatcherAssert.assertThat(render.origined(), Matchers.equalTo(false));
     }
 

--- a/jeometry-double/src/test/java/com/jeometry/render/awt/AwtPointTest.java
+++ b/jeometry-double/src/test/java/com/jeometry/render/awt/AwtPointTest.java
@@ -48,10 +48,12 @@ public final class AwtPointTest {
     @Test
     public void rendersPoints() {
         final AwtPoint painter = new AwtPoint(new Decimal());
-        painter.setContext(new AwtDrawableSurface().context());
         final Graphics2D graphics = Mockito.mock(Graphics2D.class);
-        painter.setGraphics(graphics);
-        painter.render(new Shape<>(new RandomPoint<>()));
+        painter.render(
+            new Shape<>(new RandomPoint<>()),
+            new AwtDrawableSurface().context(),
+            graphics
+        );
         Mockito.verify(graphics).drawRect(
             Mockito.anyInt(), Mockito.anyInt(),
             Mockito.anyInt(), Mockito.anyInt()
@@ -64,14 +66,13 @@ public final class AwtPointTest {
     @Test
     public void usesRightColor() {
         final AwtPoint painter = new AwtPoint(new Decimal());
-        painter.setContext(new AwtDrawableSurface().context());
         final Graphics2D graphics = Mockito.mock(Graphics2D.class);
-        painter.setGraphics(graphics);
         painter.render(
             new Shape<>(
                 new RandomPoint<>(),
                 new StrokeStyle(Color.CYAN, Dash.SOLID, 1.f)
-            )
+            ),
+            new AwtDrawableSurface().context(), graphics
         );
         Mockito.verify(graphics).drawRect(
             Mockito.anyInt(), Mockito.anyInt(),
@@ -87,9 +88,11 @@ public final class AwtPointTest {
     public void doesNotRenderOthers() {
         final SpyLine<Double> render = new SpyLine<>();
         final AwtPoint painter = new AwtPoint(new Decimal());
-        painter.setContext(new AwtDrawableSurface().context());
-        painter.setGraphics(Mockito.mock(Graphics2D.class));
-        painter.render(new Shape<>(render));
+        painter.render(
+            new Shape<>(render),
+            new AwtDrawableSurface().context(),
+            Mockito.mock(Graphics2D.class)
+        );
         MatcherAssert.assertThat(render.directioned(), Matchers.equalTo(false));
         MatcherAssert.assertThat(render.pointed(), Matchers.equalTo(false));
     }

--- a/jeometry-double/src/test/java/com/jeometry/render/awt/AwtRayTest.java
+++ b/jeometry-double/src/test/java/com/jeometry/render/awt/AwtRayTest.java
@@ -49,9 +49,11 @@ public final class AwtRayTest {
             new DblPoint(0., 0.), new DblPoint(1., 1.)
         );
         final AwtRay painter = new AwtRay(new Decimal());
-        painter.setContext(new AwtDrawableSurface().context());
-        painter.setGraphics(Mockito.mock(Graphics2D.class));
-        painter.render(new Shape<>(ray));
+        painter.render(
+            new Shape<>(ray),
+            new AwtDrawableSurface().context(),
+            Mockito.mock(Graphics2D.class)
+        );
         MatcherAssert.assertThat(ray.directioned(), Matchers.equalTo(true));
         MatcherAssert.assertThat(ray.origined(), Matchers.equalTo(true));
     }
@@ -65,9 +67,11 @@ public final class AwtRayTest {
             new DblPoint(0., 0.), new DblPoint(-1., -1.)
         );
         final AwtRay painter = new AwtRay(new Decimal());
-        painter.setContext(new AwtDrawableSurface().context());
-        painter.setGraphics(Mockito.mock(Graphics2D.class));
-        painter.render(new Shape<>(ray));
+        painter.render(
+            new Shape<>(ray),
+            new AwtDrawableSurface().context(),
+            Mockito.mock(Graphics2D.class)
+        );
         MatcherAssert.assertThat(ray.directioned(), Matchers.equalTo(true));
         MatcherAssert.assertThat(ray.origined(), Matchers.equalTo(true));
     }
@@ -81,9 +85,11 @@ public final class AwtRayTest {
             new DblPoint(0., 0.), new DblPoint(0., 1.)
         );
         final AwtRay painter = new AwtRay(new Decimal());
-        painter.setContext(new AwtDrawableSurface().context());
-        painter.setGraphics(Mockito.mock(Graphics2D.class));
-        painter.render(new Shape<>(ray));
+        painter.render(
+            new Shape<>(ray),
+            new AwtDrawableSurface().context(),
+            Mockito.mock(Graphics2D.class)
+        );
         MatcherAssert.assertThat(ray.directioned(), Matchers.equalTo(true));
         MatcherAssert.assertThat(ray.origined(), Matchers.equalTo(true));
     }
@@ -97,9 +103,11 @@ public final class AwtRayTest {
             new DblPoint(0., 0.), new DblPoint(0., -1.)
         );
         final AwtRay painter = new AwtRay(new Decimal());
-        painter.setContext(new AwtDrawableSurface().context());
-        painter.setGraphics(Mockito.mock(Graphics2D.class));
-        painter.render(new Shape<>(ray));
+        painter.render(
+            new Shape<>(ray),
+            new AwtDrawableSurface().context(),
+            Mockito.mock(Graphics2D.class)
+        );
         MatcherAssert.assertThat(ray.directioned(), Matchers.equalTo(true));
         MatcherAssert.assertThat(ray.origined(), Matchers.equalTo(true));
     }
@@ -111,9 +119,11 @@ public final class AwtRayTest {
     public void doesNotRenderOthers() {
         final SpyAngle<Double> render = new SpyAngle<>();
         final AwtRay painter = new AwtRay(new Decimal());
-        painter.setContext(new AwtDrawableSurface().context());
-        painter.setGraphics(Mockito.mock(Graphics2D.class));
-        painter.render(new Shape<>(render));
+        painter.render(
+            new Shape<>(render),
+            new AwtDrawableSurface().context(),
+            Mockito.mock(Graphics2D.class)
+        );
         MatcherAssert.assertThat(render.origined(), Matchers.equalTo(false));
     }
 

--- a/jeometry-double/src/test/java/com/jeometry/render/awt/AwtSegmentTest.java
+++ b/jeometry-double/src/test/java/com/jeometry/render/awt/AwtSegmentTest.java
@@ -46,9 +46,11 @@ public final class AwtSegmentTest {
     public void rendersSegments() {
         final SpySegment<Double> segment = new SpySegment<>();
         final AwtSegment painter = new AwtSegment(new Decimal());
-        painter.setContext(new AwtDrawableSurface().context());
-        painter.setGraphics(Mockito.mock(Graphics2D.class));
-        painter.render(new Shape<>(segment));
+        painter.render(
+            new Shape<>(segment),
+            new AwtDrawableSurface().context(),
+            Mockito.mock(Graphics2D.class)
+        );
         MatcherAssert.assertThat(segment.started(), Matchers.equalTo(true));
         MatcherAssert.assertThat(segment.ended(), Matchers.equalTo(true));
     }
@@ -60,9 +62,11 @@ public final class AwtSegmentTest {
     public void doesNotRenderOthers() {
         final SpyLine<Double> render = new SpyLine<>();
         final AwtSegment painter = new AwtSegment(new Decimal());
-        painter.setContext(new AwtDrawableSurface().context());
-        painter.setGraphics(Mockito.mock(Graphics2D.class));
-        painter.render(new Shape<>(render));
+        painter.render(
+            new Shape<>(render),
+            new AwtDrawableSurface().context(),
+            Mockito.mock(Graphics2D.class)
+        );
         MatcherAssert.assertThat(render.directioned(), Matchers.equalTo(false));
         MatcherAssert.assertThat(render.pointed(), Matchers.equalTo(false));
     }


### PR DESCRIPTION
Resolving issue #192 
Making AbstractAwtPaint immutable.
Renderer interface method takes now Surface and Graphics2D objects.
Add a default Surface constructor especially for testing (or mocking) purpose.